### PR TITLE
decorator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+
+add_definitions(-std=c++11)
+
+set(CXX_FLAGS "-Wall")
+set(CMAKE_CXX_FLAGS, "${CXX_FLAGS}")
+
+set(CMAKE_BUILD_TYPE Debug)
+
+project(test)
+
+include_directories(
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src
+)
+
+file(GLOB all_SRCS
+    "${PROJECT_SOURCE_DIR}/*.cpp"
+    "${PROJECT_SOURCE_DIR}/include/*.h"
+    "${PROJECT_SOURCE_DIR}/src/*.cpp"
+)
+add_executable(Decorator ${all_SRCS})

--- a/include/Decorator.h
+++ b/include/Decorator.h
@@ -1,0 +1,45 @@
+#ifndef DECORATOR_H
+#define DECORATOR_H
+#include <Giant.h>
+
+class Power : public Giant {
+    Giant* eaten_giant;
+public:
+    Power(string n, string p) : Giant(n, p) {};
+    virtual void be_eaten(Giant* a){
+        eaten_giant = a;
+    }
+    virtual void introuduce() override {
+        if(nullptr != eaten_giant){
+            eaten_giant->introuduce();
+        }
+    }
+};
+
+class OriginGiant : public Power{
+public:
+    OriginGiant(): Power("Yumiru", "POINTER!") {};
+    virtual void introuduce() final{
+        Power::introuduce();
+        cout << this->power << " from " << this->name << endl;
+    }
+};
+
+class ArmoredGiant : public Power{
+public:
+    ArmoredGiant(): Power("Linar", "Split Personality!") {};
+    virtual void introuduce() final{
+        Power::introuduce();
+        cout << this->power << " from " << this->name << endl;
+    }
+};
+
+class WomanGiant : public Power{
+public:
+    WomanGiant(): Power("Annie", "MARTIAL-ATTACK!") {};
+    virtual void introuduce() final{
+        Power::introuduce();
+        cout << this->power << " from " << this->name << endl;
+    }
+};
+#endif

--- a/include/Giant.h
+++ b/include/Giant.h
@@ -1,0 +1,18 @@
+#ifndef GIANT_H
+#define GIANT_H
+
+#include <string>
+#include <iostream>
+using namespace std;
+
+class Giant {
+public:    
+    string name;
+    string power;
+    Giant(string name="", string power="");
+
+    ///// got a public function as a baseline.
+    ///// It could be decorated or NOT decorated. Both are fine!
+    virtual void introuduce();
+};
+#endif

--- a/src/Giant.cpp
+++ b/src/Giant.cpp
@@ -1,0 +1,11 @@
+#include <Giant.h>
+
+Giant::Giant(string name, string power){
+    this->name = name;
+    this->power = power;
+}
+
+void Giant::introuduce() {
+    cout << "I am giant " << name << endl;
+    cout << "I got power of these giants: " << endl;
+};

--- a/test.cpp
+++ b/test.cpp
@@ -1,0 +1,24 @@
+#include <iostream>
+#include <Decorator.h>
+#include <Giant.h>
+using namespace std;
+
+int main(int argv, char ** argc){
+    Giant* alen = new Giant("Alen", "None");
+
+    Power* yumiru = new OriginGiant();
+    Power* annie = new WomanGiant();
+    Power* linar = new ArmoredGiant();
+    
+    yumiru->be_eaten(alen);
+    annie->be_eaten(yumiru);
+    linar->be_eaten(annie);
+    linar->introuduce();
+
+    delete alen;
+    delete yumiru;
+    delete annie;
+    delete linar;
+
+    return 0;
+}


### PR DESCRIPTION
Add `decorator` design patter: 將業務邏輯組織為層次結構，將各種不同邏輯組合在客戶端接起來使用，以避免多種組合要寫出無數種classes的窘況。